### PR TITLE
Cannot run an installed gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,13 @@ ruby::plugin { 'rbenv-vars':
   version => 'v1.2.0',
   source  => 'sstephenson/rbenv-vars'
 }
+
+# Run an installed gem
+# rbenv-installed gems cannot be run in the boxen installation environment which uses the system
+# ruby. The environment must be cleared (env -i) so an installed ruby (and gems) can be used in a new shell.
+exec { "env -i zsh -c 'source /opt/boxen/env.sh && RBENV_VERSION=${version} bundle install'":
+  provider => 'shell',
+  cwd => "~/src/project",
+  require => [ Ruby::Gem["bundler for ${version}"], Package['zsh'] ]
+}
 ```


### PR DESCRIPTION
I'm trying to run a number of gems as part of my boxen setup, but I can't seem to make it work. I suspect it's an environment/PATH issue which I don't understand. I'm hoping someone here might help me.

Since my boxen repo is getting complicated, I re-created a minimal example cloned from the our-boxen repo [here](https://gist.github.com/AlphaHydrae/6520819).

What I want to do here is install and run my gitenv gem which manages my symlinks. These are the relevant parts of the manifests/site.pp:

```
  include ruby::1_9_3

  $global_ruby_version = '1.9.3-p392'

  class { 'ruby::global':
    version => $global_ruby_version
  }

  ruby::gem { "gitenv for ${global_ruby_version}":
    gem => 'gitenv',
    ruby => $global_ruby_version,
    version => '~> 0.0.5'
  }

  ruby::plugin { 'gem-rehash':
    version => 'v1.0.0',
    source  => 'sstephenson/rbenv-gem-rehash'
  }

  # modules/projects/manifests/env.pp (project containing my dotfiles)
  include projects::env

  # try to use gem
  exec { "zsh -c 'source /opt/boxen/env.sh && gitenv -c ~/src/env/.gitenv.rb'":
    cwd => "/Users/${luser}",
    logoutput => true,
    require => [ Boxen::Project['env'], Ruby::Gem["gitenv for ${global_ruby_version}"], Ruby::Plugin['gem-rehash'], Class['ruby::global'], Package['zsh'] ]
  }
```

It fails with this error:

```
/Library/Ruby/Gems/1.8/gems/bundler-1.2.5/lib/bundler/spec_set.rb:90:in `block in materialize': Could not find addressable-2.3.2 in any of the sources (Bundler::GemNotFound)
  from /Library/Ruby/Gems/1.8/gems/bundler-1.2.5/lib/bundler/spec_set.rb:83:in `map!'
    from /Library/Ruby/Gems/1.8/gems/bundler-1.2.5/lib/bundler/spec_set.rb:83:in `materialize'
    from /Library/Ruby/Gems/1.8/gems/bundler-1.2.5/lib/bundler/definition.rb:113:in `specs'
    from /Library/Ruby/Gems/1.8/gems/bundler-1.2.5/lib/bundler/definition.rb:158:in `specs_for'
    from /Library/Ruby/Gems/1.8/gems/bundler-1.2.5/lib/bundler/definition.rb:147:in `requested_specs'
    from /Library/Ruby/Gems/1.8/gems/bundler-1.2.5/lib/bundler/environment.rb:23:in `requested_specs'
    from /Library/Ruby/Gems/1.8/gems/bundler-1.2.5/lib/bundler/runtime.rb:11:in `setup'
    from /Library/Ruby/Gems/1.8/gems/bundler-1.2.5/lib/bundler.rb:116:in `setup'
    from /Library/Ruby/Gems/1.8/gems/bundler-1.2.5/lib/bundler/setup.rb:17:in `<top (required)>'
    from /opt/boxen/rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /opt/boxen/rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
```

Kind of looks like something is being interpreted with the 1.8 system ruby? I then tried to output some more information with another exec to see what's going on:

```
  exec { "zsh -c 'source /opt/boxen/env.sh && rbenv version && which gitenv'":
    cwd => "/Users/${luser}",
    logoutput => true,
    require => [ Boxen::Project['env'], Ruby::Gem["gitenv for ${global_ruby_version}"], Ruby::Plugin['gem-rehash'], Class['ruby::global'], Package['zsh'] ]
  }
```

This outputs:

```
1.9.3-p392 (set by /opt/boxen/rbenv/version)
/opt/boxen/rbenv/shims/gitenv
```

So it looks like rbenv is set up correctly, but it still won't execute my gem. See full log output here: https://gist.github.com/AlphaHydrae/5429361

I found [this post](https://github.com/sstephenson/rbenv/issues/329) which seemed relevant about how `#!/usr/bin/env ruby` wouldn't work with rbenv shims if you don't export the PATH. But adding an `export PATH=/opt/boxen/rbenv/shims:$PATH` didn't do the trick. It looks like it's set up correctly anyway from the log output.

Just for fun, I put this script in `~/test.rb`:

```
#!/usr/bin/env ruby
puts RUBY_VERSION
```

And I tried to execute it with the same kind of command in an exec:

```
zsh -lc 'source /opt/boxen/env.sh && ~/test.rb'
```

It fails with the exact same stack trace.

Note that after the boxen install, if I source the boxen environment, my gitenv gem and this test script run fine. It's only when I try to run them during the boxen setup that they won't work.

(In case anyone wants to point it out, I know that boxen can create symlinks, but the syntax is bulky and that doesn't solve the general problem of running a gem on installation, which I need to do with several other gems.)
