### PR TITLE
bump ruby-build version to fix compiler optimization bug

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,7 @@ class ruby {
 
   $root = "${boxen::config::home}/rbenv"
   $rbenv_version = 'v0.4.0'
-  $ruby_build_version = 'v20130408'
+  $ruby_build_version = 'v20130501'
   $rbenv_gem_rehash_version = 'v1.0.0'
 
   file {


### PR DESCRIPTION
Addresses huge performance problems with compiled rubies not being properly optimized.  Due to this bug, recent versions of ruby installed via boxen+rbenv+ruby-build are currently very slow -- this addresses that issue. (I know for certain with my testing it affects `2.0.0` and I believe also possibly `1.9.3`)

See sstephenson/ruby-build#335 and sstephenson/ruby-build#340 and probably most importantly sstephenson/ruby-build#351.

Here is a speed comparison with some trivial code on my system:

```
// ruby-2.0.0 unoptimized (current boxen default)
$ time ./fizzbuzz.rb 1000000 > /dev/null 
./fizzbuzz.rb 1000000 > /dev/null  2.12s user 0.06s system 98% cpu 2.220 total

// ruby-2.0.0 recompiled after ruby-build fix applied
$ time ./fizzbuzz.rb 1000000 > /dev/null 
./fizzbuzz.rb 1000000 > /dev/null  0.65s user 0.04s system 98% cpu 0.704 total
```

The performance difference is as much as 300-400%!

_Note: Because of `try_to_download_ruby_version.bash` the precompiled ruby binaries that Boxen hosts on S3 will also need to be recompiled after this.  I don't believe there is a way for me to do that via a pull request(?), so the Boxen maintainers will need to do so after merging this._
