### PR TITLE
Custom bucket to download rubies

### DIFF
--- a/files/try_to_download_ruby_version.bash
+++ b/files/try_to_download_ruby_version.bash
@@ -4,12 +4,12 @@ if [ -z "$SKIP_PRECOMPILED_RUBIES" ]; then
   VERSION_NAME="${DEFINITION##*/}"
   VERSIONS_DIR="${RBENV_ROOT}/versions"
   OSX_RELEASE=`sw_vers -productVersion | cut -f 1-2 -d '.'`
-
+  DOWNLOAD_BUCKET=${BOXEN_RUBIES_BUCKET-"boxen-downloads"}
   PREV_PWD=`pwd`
 
   cd $VERSIONS_DIR
   echo "Trying to download precompiled Ruby from Boxen..."
-  curl -s -f http://s3.amazonaws.com/boxen-downloads/rbenv/$OSX_RELEASE/$VERSION_NAME.tar.bz2 > /tmp/ruby-$VERSION_NAME.tar.bz2 && \
+  curl -s -f http://s3.amazonaws.com/$DOWNLOAD_BUCKET/rbenv/$OSX_RELEASE/$VERSION_NAME.tar.bz2 > /tmp/ruby-$VERSION_NAME.tar.bz2 && \
     tar xjf /tmp/ruby-$VERSION_NAME.tar.bz2 && rm -rf /tmp/ruby-$VERSION_NAME.tar.bz2
   cd $PREV_PWD
 


### PR DESCRIPTION
Hey guys!

I was thinking about hosting precompiled rubies with readline support for me and some coworkers at Plataformatec, and the only thing missing was the ability to download tarballs from our own bucket instead of `boxen-downloads`, since `script/sync` already support something like this.

Currently the variable is `BOXEN_RUBIES_BUCKET` because we don't want to reuse `BOXEN_S3_BUCKET` since we don't plan on storing Homebrew/nodenv tarballs, only rbenv ones, otherwise we would have to host a lot of the same packages that `boxen-downloads` already has, and I'm not sure if there is a better way to use our bucket _only_ for rubies. 

What do you guys think, any alternative or naming pattern that would fit better this use case?

/cc @rafaelfranca
