### PR TITLE
Don't need xquartz to install REE

### DIFF
--- a/manifests/ree_1_8_7_2012_02.pp
+++ b/manifests/ree_1_8_7_2012_02.pp
@@ -6,7 +6,6 @@
 
 class ruby::ree_1_8_7_2012_02 {
   require gcc
-  require xquartz
 
   case $::osfamily {
     Darwin: {
@@ -14,7 +13,6 @@ class ruby::ree_1_8_7_2012_02 {
 
       $env = {
         'CC'       => "${boxen::config::home}/homebrew/bin/gcc-4.2",
-        'CPPFLAGS' => '-I/opt/X11/include',
       }
     }
 

--- a/spec/classes/ree_1_8_7_2012_02_spec.rb
+++ b/spec/classes/ree_1_8_7_2012_02_spec.rb
@@ -5,11 +5,9 @@ describe "ruby::ree_1_8_7_2012_02" do
 
   it do
     should include_class('gcc')
-    should include_class('xquartz')
 
     should contain_ruby__version('ree-1.8.7-2012.02').with({
       :env => {
-        'CPPFLAGS' => '-I/opt/X11/include',
         'CC'       => '/test/boxen/homebrew/bin/gcc-4.2',
       }
     })


### PR DESCRIPTION
Since https://github.com/sstephenson/ruby-build/commit/353246926c9273329391915a125ff241e9954ba6 the default REE instalation will not try to install with tk