### PR TITLE
Install openssl for ruby 2.0.0-github3

### DIFF
--- a/files/definitions/2.0.0-github3
+++ b/files/definitions/2.0.0-github3
@@ -1,2 +1,3 @@
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-2.0.0-github3" "https://s3.amazonaws.com/boxen-downloads/ruby-build/ruby-2.0.0-github3.tar.gz#70b5a2f59b611df4ebaa382a5a1525b4" autoconf standard
+install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.0.0-github3" "https://s3.amazonaws.com/boxen-downloads/ruby-build/ruby-2.0.0-github3.tar.gz#70b5a2f59b611df4ebaa382a5a1525b4" autoconf standard verify_openssl


### PR DESCRIPTION
Copy pasted some stuff out of the official ruby-build definition for 2.0.0-p247.

I've verified it works on my system, but I've already got OpenSSL installed so it didn't actually download and install OpenSSL.
