### PR TITLE
Use the boxen s3 configuration in the environment for the rbenv install

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -17,7 +17,9 @@ define ruby::version(
       require xquartz
 
       $os_env = {
-        'CFLAGS' => '-I/opt/X11/include'
+        'BOXEN_S3_HOST'   => $::boxen_s3_host,
+        'BOXEN_S3_BUCKET' => $::boxen_s3_bucket,
+        'CFLAGS'          => '-I/opt/X11/include'
       }
     }
 

--- a/spec/defines/ruby_version_spec.rb
+++ b/spec/defines/ruby_version_spec.rb
@@ -22,6 +22,8 @@ describe 'ruby::version' do
     context "when env is default" do
       it do
         should contain_exec('ruby-install-1.9.3-p194').with_environment([
+          "BOXEN_S3_BUCKET=boxen-downloads",
+          "BOXEN_S3_HOST=s3.amazonaws.com",
           "CC=/usr/bin/cc",
           "CFLAGS=-I/opt/X11/include",
           "RBENV_ROOT=/test/boxen/rbenv"
@@ -38,6 +40,8 @@ describe 'ruby::version' do
 
       it do
         should contain_exec('ruby-install-1.9.3-p194').with_environment([
+          "BOXEN_S3_BUCKET=boxen-downloads",
+          "BOXEN_S3_HOST=s3.amazonaws.com",
           "CC=/usr/bin/cc",
           "CFLAGS=-I/opt/X11/include",
           "RBENV_ROOT=/test/boxen/rbenv",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ def default_test_facts
   {
     :boxen_home                  => "/test/boxen",
     :boxen_user                  => "testuser",
+    :boxen_s3_host               => "s3.amazonaws.com",
+    :boxen_s3_bucket             => "boxen-downloads",
     :macosx_productversion_major => "10.8",
     :osfamily                    => "Darwin",
   }


### PR DESCRIPTION
This will make posible to change the s3 configuration to get the precompiled packages.

Related with https://github.com/boxen/boxen/pull/123 and https://github.com/boxen/puppet-boxen/pull/71.

cc @wfarr @boxen/owners 
