### PR TITLE
Remove rogue quotes on flags

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -20,8 +20,8 @@ define ruby::version(
       $os_env = {
         'BOXEN_S3_HOST'   => $::boxen_s3_host,
         'BOXEN_S3_BUCKET' => $::boxen_s3_bucket,
-        'CFLAGS'          => "'-I${homebrew::config::installdir}/include -I/opt/X11/include'",
-        'LDFLAGS'         => "'-L${homebrew::config::installdir}/lib -L/opt/X11/lib'",
+        'CFLAGS'          => "-I${homebrew::config::installdir}/include -I/opt/X11/include",
+        'LDFLAGS'         => "-L${homebrew::config::installdir}/lib -L/opt/X11/lib",
       }
     }
 


### PR DESCRIPTION
Resolves breakage mentioned here https://github.com/boxen/puppet-ruby/commit/8a6a1fb37923fe021c44aab1dc499b46b266e3c9#commitcomment-4530172 but fails the build without the apostrophes. Need to look into this more.  
