### PR TITLE
Remove version alias for 2.1.0

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -16,6 +16,5 @@ ruby::version::alias:
   1.9.3-p231-tcs-github: 1.9.3-p231-tcs-github-1.0.32
   2.0.0: 2.0.0-p353
   2.0.0-github: 2.0.0-github6
-  2.1.0: 2.1.0-preview2
   jruby: jruby-1.7.6
   ree: ree-1.8.7-2012.02


### PR DESCRIPTION
After the 2.1.0 ruby will not use the patchlevel for 2.1+ releases.

The next release will be 2.1.1 so we don't need these aliases anymore.

See https://github.com/sstephenson/ruby-build/commit/9e76ceb8bf772115e34c98802826da3884dd0b2c and linked tweet.
