### PR TITLE
Pass ldflags_dirs to ruby-build

### DIFF
--- a/files/definitions/2.1.0-github1
+++ b/files/definitions/2.1.0-github1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.0-github1" "https://s3.amazonaws.com/boxen-downloads/ruby-build/ruby-2.1.0-github1.tar.gz#a8b528f2e0d5ecf55893002078014beb" autoconf standard verify_openssl
+install_package "ruby-2.1.0-github1" "https://s3.amazonaws.com/boxen-downloads/ruby-build/ruby-2.1.0-github1.tar.gz#a8b528f2e0d5ecf55893002078014beb" ldflags_dirs autoconf standard verify_openssl


### PR DESCRIPTION
This tells ruby-build to ensure `$PREFIX/lib` exists before calling Ruby's `./configure` to work around build issues caused Ruby 2.1.0's stricter checking of `LDFLAGS` and ruby-build passing lib directories in `LDFLAGS` that don't exist.

cc @dgoodlad @wfarr 
