### PR TITLE
Add new GitHub Ruby 2.1.1

### DIFF
--- a/files/definitions/2.1.1-github1
+++ b/files/definitions/2.1.1-github1
@@ -1,0 +1,2 @@
+install_package "openssl-1.0.1f" "https://www.openssl.org/source/openssl-1.0.1f.tar.gz#f26b09c028a0541cab33da697d522b25" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.1.1-github1" "https://s3.amazonaws.com/boxen-downloads/ruby-build/ruby-2.1.1-github1.tar.gz#dd81268aaa87a7b200f40ad53ac47227" ldflags_dirs autoconf standard verify_openssl


### PR DESCRIPTION
This adds the definition for GitHub Ruby 2.1.1
