### PR TITLE
Improve zsh support

### DIFF
--- a/templates/ruby.sh
+++ b/templates/ruby.sh
@@ -28,7 +28,8 @@ source <%= scope.lookupvar("::ruby::chruby::prefix") %>/share/chruby/auto.sh
 <%- end -%>
 
 # Load global rubies
-export RUBIES=(/opt/rubies/*)
+RUBIES=(/opt/rubies/*)
+export RUBIES
 
 # Helper for shell prompts and the like
 current-ruby() {


### PR DESCRIPTION
With the original version I'm getting `zsh: unknown sort specifier`, even from
a non customized shell (version 5.0.5).
