### PR TITLE
Put Java into the path for jruby gems

### DIFF
--- a/lib/puppet/provider/ruby_gem/rubygems.rb
+++ b/lib/puppet/provider/ruby_gem/rubygems.rb
@@ -140,7 +140,7 @@ private
       :failonfail         => true,
       :uid                => user,
       :custom_environment => {
-        "PATH" => env_path(bindir, ruby_version),
+        "PATH" => env_path(bindir),
         "GEM_PATH" => nil
       }
     }
@@ -179,11 +179,7 @@ private
     end
   end
 
-  def env_path(bindir, ruby_version)
-    if ruby_version.start_with?('jruby')
-      [bindir, "#{Facter.value(:boxen_home)}/bin"].join(':')
-    else
-      bindir
-    end
+  def env_path(bindir)
+    [bindir, "#{Facter.value(:boxen_home)}/bin"].join(':')
   end
 end


### PR DESCRIPTION
## Issue

Trying to [install "bundler" for all Rubies](https://github.com/boxen/puppet-ruby/commit/1794fa17b04cd19a68365ebc272e6b2a71c7185c) currently results in:

> ```
> Puppet (err): Execution of '/opt/rubies/jruby-1.7.4/bin/gem install 'bundler' --version '~> 1.0' --source 'https://rubygems.org/' --no-rdoc --no-ri --verbose' returned 255: No `java' executable found on PATH.
> ```

...if `jruby` is one of your rubies!

But `java` is installed in `/opt/boxen/bin` by https://github.com/boxen/puppet-java for jruby (see https://github.com/boxen/puppet-ruby/blob/master/manifests/version.pp#L28 ).
## Change

Add Boxen's `bin` directory to `${PATH}` when installing gems if the Ruby version is a `jruby` version.
## [The start of the conversation](https://github.com/boxen/puppet-ruby/blob/master/CONTRIBUTING.md)

This could really do with a spec, but I have no idea where to start. I'll hang out in #boxen for a while should anyone (@dgoodlad?) want to walk me through.

FWIW I've tested this on a couple of boxes and it works :-)
