### PR TITLE
Rubygem provider bugfixes

### DIFF
--- a/lib/puppet/provider/ruby_gem/rubygems.rb
+++ b/lib/puppet/provider/ruby_gem/rubygems.rb
@@ -182,6 +182,8 @@ private
   end
 
   def env_path(bindir)
-    [bindir, "#{Facter.value(:boxen_home)}/bin"].join(':')
+    [bindir,
+     "#{Facter.value(:boxen_home)}/bin",
+     "/usr/bin", "/bin", "/usr/sbin", "/sbin"].join(':')
   end
 end


### PR DESCRIPTION
- Specifying a `ruby_version` other than `*` is fixed; it used to raise an "undefined method map for nil:Nilclass" exception
- Installing native gems works again; they need the compiler toolchain on the PATH (e.g. `gcc` and `make`)
