### PR TITLE
Build rubies on Darwin against homebrew readline

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -5,7 +5,7 @@ ruby::version::env:
     BOXEN_S3_BUCKET: "%{::boxen_s3_bucket}"
     CFLAGS: "-I%{::homebrew::config::installdir}/include -I/opt/X11/include"
     LDFLAGS: "-L%{::homebrew::config::installdir}/lib -L/opt/X11/lib"
-    RUBY_CONFIGURE_OPTS: "--without-gmp"
+    RUBY_CONFIGURE_OPTS: "--without-gmp --with-readline-dir=%{::homebrew::config::installdir}/opt/readline"
 
   1.8.7-p358:
     RUBY_CONFIGURE_OPTS: "--disable-tk --disable-tcl --disable-tcltk-framework"

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -37,6 +37,8 @@ define ruby::version(
       require xquartz
       include homebrew::config
       include boxen::config
+      ensure_resource('package', 'readline')
+      Package['readline'] -> Ruby <| |>
     }
 
     $hierdata = hiera_hash('ruby::version::env', {})


### PR DESCRIPTION
The OSX-supplied `libreadline` is actually just a symlink to `libedit3`, which among other things doesn't support unicode very well.

cc @muan
