### PR TITLE
Fix downloading ruby versions with reserved chars

### DIFF
--- a/lib/puppet/provider/ruby/rubybuild.rb
+++ b/lib/puppet/provider/ruby/rubybuild.rb
@@ -83,7 +83,7 @@ private
       /
       #{os_release}
       /
-      #{version}.tar.bz2
+      #{CGI.escape(version)}.tar.bz2
     ).join("")
   end
 


### PR DESCRIPTION
A ruby version like 2.1.2+github1 would fail to download, because `+` is a reserved character in URLs.
