### PR TITLE
ree needs CFLAGS

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -18,6 +18,7 @@ ruby::version::env:
 
   ree-1.8.7-2012.02:
     CC: "gcc-4.2"
+    CFLAGS: "-O2 -fno-optimize-sibling-calls"
 
 ruby::prefix: "%{::boxen::config::home}"
 ruby::user: "%{::boxen_user}"

--- a/data/Darwin/10.9.yaml
+++ b/data/Darwin/10.9.yaml
@@ -1,6 +1,3 @@
 ruby::version::env:
   1.8.7-p358:
     CC: "gcc-4.8"
-
-  ree-1.8.7-2012.02:
-    CC: "gcc-4.8"


### PR DESCRIPTION
fails to build without ... succeeds with

error I got before adding this:

```
/opt/boxen/rbenv/versions/ree-1.8.7-2012.02/lib/ruby/1.8/timeout.rb:60: [BUG] Segmentation fault
ruby 1.8.7 (2012-02-08 MBARI 8/0x6770 on patchlevel 358) [i686-darwin13.2.0], MBARI 0x6770, Ruby Enterprise Edition 2012.02
```

@dgoodlad
