### PR TITLE
Fix REE build flags, and use gcc-4.8 by default

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -8,6 +8,7 @@ ruby::version::env:
     RUBY_CONFIGURE_OPTS: "--without-gmp --with-readline-dir=%{::homebrew::config::installdir}/opt/readline"
 
   1.8.7-p358:
+    CC: "gcc-4.8"
     RUBY_CONFIGURE_OPTS: "--disable-tk --disable-tcl --disable-tcltk-framework"
 
   1.9.2-p290:
@@ -17,7 +18,7 @@ ruby::version::env:
     CC: "gcc-4.2"
 
   ree-1.8.7-2012.02:
-    CC: "gcc-4.2"
+    CC: "gcc-4.8"
     CFLAGS: "-O2 -fno-tree-dce -fno-optimize-sibling-calls"
 
 ruby::prefix: "%{::boxen::config::home}"

--- a/data/Darwin/10.8.yaml
+++ b/data/Darwin/10.8.yaml
@@ -1,3 +1,6 @@
 ruby::version::env:
   1.8.7-p358:
     CC: "gcc-4.2"
+
+  ree-1.8.7-2012.02:
+    CC: "gcc-4.2"

--- a/data/Darwin/10.9.yaml
+++ b/data/Darwin/10.9.yaml
@@ -1,3 +1,1 @@
-ruby::version::env:
-  1.8.7-p358:
-    CC: "gcc-4.8"
+---


### PR DESCRIPTION
This builds on #112, but reverts the switch to gcc 4.2.

I've successfully built ree using gcc 4.8 on both Mavericks and Yosemite. I believe the 4.8 issues reported in #112 were related to a bad 4.8 compiler rather than bugs building Ruby.

See https://github.com/sstephenson/ruby-build/issues/488 for the source of the updated `CFLAGS`

Fixes #80 

cc @grosser @rafaelfranca 
