### PR TITLE
Bump ruby-build version to 20140919

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -24,7 +24,7 @@ ruby::prefix: '/opt'
 ruby::provider: 'rbenv'
 ruby::user: "%{::id}"
 
-ruby::build::ensure: 'ee04b9d3c542bed4781acad33dbe0fd0563925e6'
+ruby::build::ensure: 'v20140919'
 ruby::build::prefix: "%{hiera('ruby::prefix')}/ruby-build"
 ruby::build::user: "%{hiera('ruby::user')}"
 


### PR DESCRIPTION
This updates the version of ruby build so that `2.1.3` is available in the definitions list.
