### PR TITLE
Bump ruby-build to v20141028 to support Ruby 2.1.4 definitions

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -24,7 +24,7 @@ ruby::prefix: '/opt'
 ruby::provider: 'rbenv'
 ruby::user: "%{::id}"
 
-ruby::build::ensure: 'v20140919'
+ruby::build::ensure: 'v20141028'
 ruby::build::prefix: "%{hiera('ruby::prefix')}/ruby-build"
 ruby::build::user: "%{hiera('ruby::user')}"
 


### PR DESCRIPTION
Just because there are more security bugs :)
