### PR TITLE
Bump ruby-build version and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The ruby-build version is something you should be managing in your own boxen rep
 rather than depending on this module to update for you. See examples on how to change the ruby-build
 version in the Hiera section.
 
+You can find a release list of versions for ruby-build [here](https://github.com/sstephenson/ruby-build/releases).
+
 ## Breakages since last major version
 
 * `ruby::global` does not work with chruby
@@ -81,7 +83,7 @@ The following variables may be automatically overridden with Hiera:
 "ruby::provider": "chruby"
 "ruby::user": "deploy"
 
-"ruby::build::ensure": "v0.3.8"
+"ruby::build::ensure": "v20141028"
 "ruby::chruby::ensure": "v0.3.6"
 "ruby::rbenv::ensure": "v0.4.0"
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -24,7 +24,7 @@ ruby::prefix: '/opt'
 ruby::provider: 'rbenv'
 ruby::user: "%{::id}"
 
-ruby::build::ensure: 'v20140919'
+ruby::build::ensure: 'v20141028'
 ruby::build::prefix: "%{hiera('ruby::prefix')}/ruby-build"
 ruby::build::user: "%{hiera('ruby::user')}"
 


### PR DESCRIPTION
I was slightly confused by the README, given that it listed a `v0.3.8`
as the version number in the configuration for ruby-build, where
ruby-build actually uses a date versioning number structure.

This updates the README to use a date version number as the
configuration example and adds a note to the ruby-build section as to
where you can find the latest releases.

I also bumped the default value for ruby-build to the latest release
while I was here.
