### PR TITLE
Fix for /bin/sh, which doesn't allow for dashes in variable names.

### DIFF
--- a/templates/ruby.sh
+++ b/templates/ruby.sh
@@ -13,7 +13,7 @@ export PATH=$RBENV_ROOT/bin:$PATH
 eval "$(rbenv init -)"
 
 # Helper for shell prompts and the like
-current-ruby() {
+current_ruby() {
   echo "$(rbenv version-name)"
 }
 <%- end -%>


### PR DESCRIPTION
Fixes https://github.com/boxen/puppet-ruby/issues/113.