### PR TITLE
Fix `ruby_gem` install errors on Rubinius due to encoding

### DIFF
--- a/lib/puppet/provider/ruby_gem/rubygems.rb
+++ b/lib/puppet/provider/ruby_gem/rubygems.rb
@@ -141,9 +141,11 @@ private
       :combine            => true,
       :failonfail         => true,
       :uid                => user,
+      :override_locale    => false,
       :custom_environment => {
         "PATH" => env_path(bindir),
-        "GEM_PATH" => nil
+        "GEM_PATH" => nil,
+        "LANG" => "en_US.UTF-8"
       }
     }
   end


### PR DESCRIPTION
Fixes this error when `ruby_gem` tries to install e.g. Bundler v1.6.9 on any version on Rubinius:

    invalid gem: package is corrupt, exception while verifying:
    invalid byte sequence in US-ASCII (ArgumentError)

This is due to the fact that Puppet sets `LANG=C` by default on everything it executes to ensure a level playing field. In Ruby, this sets `Encoding.default_external` to ASCII, causing the files to be read in as ASCII by default and chokes if that input has any non-ASCII characters like some gemspecs do due to authors' names. This might be a RubyGems bug (v2.2.2) but it seems to happen only on Rubinius, for reasons unknown to me. https://github.com/rubinius/rubinius/issues/3275#issuecomment-71761170

Simply setting `LANG` in custom_environment when executing `gem` commands doesn't take effect because [Puppet still overrides it](https://github.com/puppetlabs/puppet/blob/f77bd82d9bc096b74bf0c2c1b19d19490e595483/spec/unit/util/execution_spec.rb#L354-L364). This smells like a Puppet bug. To have Puppet stop overriding LANG, `:override_locale => false` is required.