### PR TITLE
Add Ruby 2.1.5

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -19,7 +19,8 @@ ruby::version::alias:
   2.1.0-github: 2.1.0-github1
   2.1.2-github: 2.1.2-github1
   2.1.4-github: 2.1.4-github1
-  2.1-github: 2.1.4-github1
+  2.1.5-github: 2.1.5-github1
+  2.1-github: 2.1.5-github1
   jruby: jruby-1.7.6
   ree: ree-1.8.7-2012.02
 
@@ -27,7 +28,7 @@ ruby::prefix: '/opt'
 ruby::provider: 'rbenv'
 ruby::user: "%{::id}"
 
-ruby::build::ensure: 'v20141028'
+ruby::build::ensure: 'v20141113'
 ruby::build::prefix: "%{hiera('ruby::prefix')}/ruby-build"
 ruby::build::user: "%{hiera('ruby::user')}"
 

--- a/files/definitions/2.1.5-github1
+++ b/files/definitions/2.1.5-github1
@@ -1,0 +1,3 @@
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "openssl-1.0.1l" "https://www.openssl.org/source/openssl-1.0.1l.tar.gz#b2cf4d48fe5d49f240c61c9e624193a6f232b5ed0baf010681e725963c40d1d4" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2_1_5_github1" "https://github.com/github/ruby/archive/v2_1_5_github1.tar.gz#003d09f172a16979c3eae7a91a46ee1db986d9c35f2d905f3c459d092f55fdf8" ldflags_dirs autoconf standard verify_openssl


### PR DESCRIPTION
I'm aware this package definition is not currently correct as it relies on binary packages being downloaded which don't exist.

It's not clear to me, though, how these packages are uploaded and what the from-source build of these packages are. Are Boxen's Rubies (e.g. `2.1.4`) patched or different from the default `ruby-build` `2.1.4`?

CC @dgoodlad @rafaelfranca @mislav 