### PR TITLE
Binary tweaks

### DIFF
--- a/lib/puppet/provider/ruby/rubybuild.rb
+++ b/lib/puppet/provider/ruby/rubybuild.rb
@@ -78,8 +78,8 @@ private
 
   def precompiled_url
     base = Facter.value(:boxen_download_url_base) ||
-      "http://#{Facter.value(:boxen_s3_host)}/#{Facter.value(:boxen_s3_bucket)}"
-    
+      "https://#{Facter.value(:boxen_s3_host)}/#{Facter.value(:boxen_s3_bucket)}"
+
     %W(
       #{base}
       /


### PR DESCRIPTION
- use https for binaries
- support more Homebrew root binaries. Binaries can now be uploaded for non-default Homebrew locations so let's use them when they are available.