### PR TITLE
Fix plugin type throwing error when not installing through hiera yaml

### DIFF
--- a/manifests/rbenv.pp
+++ b/manifests/rbenv.pp
@@ -32,13 +32,6 @@ class ruby::rbenv(
   }
 
   if !empty($plugins) and $ensure != 'absent'  {
-
-    file { "${prefix}/plugins":
-      ensure  => directory,
-      require => Repository[$prefix]
-    }
-
     create_resources('ruby::rbenv::plugin', $plugins)
-
   }
 }

--- a/manifests/rbenv/plugin.pp
+++ b/manifests/rbenv/plugin.pp
@@ -11,6 +11,13 @@ define ruby::rbenv::plugin($ensure, $source) {
   require ruby
 
   if $ruby::provider == 'rbenv' {
+
+    $plugins_dir_params =  {
+      ensure  => directory,
+      require => Repository[$ruby::rbenv::prefix]
+    }
+    ensure_resource('file', "${ruby::rbenv::prefix}/plugins", $plugins_dir_params)
+
     repository { "${ruby::rbenv::prefix}/plugins/${name}":
       ensure  => $ensure,
       force   => true,

--- a/spec/defines/ruby_rbenv_plugin_spec.rb
+++ b/spec/defines/ruby_rbenv_plugin_spec.rb
@@ -17,6 +17,7 @@ describe 'ruby::rbenv::plugin' do
   context "ensure => present" do
     it do
       should contain_class('ruby')
+      should contain_file('/test/boxen/rbenv/plugins')
       should contain_repository('/test/boxen/rbenv/plugins/rbenv-vars')
     end
   end


### PR DESCRIPTION
This pr fixes @dlackty problem https://github.com/boxen/puppet-ruby/pull/125#issuecomment-113871650 .
Thanks