### PR TITLE
use correct capitalization to avoid warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ ruby::rbenv::plugin { 'rbenv-vars':
 # Run an installed gem
 exec { '/opt/rubies/2.2.2/bin/bundle install':
   cwd     => "~/src/project",
-  require => ruby_gem['bundler for 2.2.2']
+  require => Ruby_Gem['bundler for 2.2.2']
 }
 ```
 


### PR DESCRIPTION
Warning: Deprecation notice:  Resource references should now be capitalized on line 99 in file /xxx.pp

@seanknox @mikemcquaid 