### PR TITLE
Update ruby-build version (v20150413 -> v20151024)

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -29,7 +29,7 @@ ruby::prefix: '/opt'
 ruby::provider: 'rbenv'
 ruby::user: "%{::id}"
 
-ruby::build::ensure: 'v20150413'
+ruby::build::ensure: 'v20151024'
 ruby::build::prefix: "%{hiera('ruby::prefix')}/ruby-build"
 ruby::build::user: "%{hiera('ruby::user')}"
 


### PR DESCRIPTION
This version has fixes for build Ruby 1.9.3 on Mac OS X 10.11 El Capitan.
See https://github.com/sstephenson/ruby-build/pull/808