### PR TITLE
Fish Compatibility

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ class ruby(
 
   if $::osfamily == 'Darwin' {
     boxen::env_script { 'ruby-fish':
-      content  => template('ruby/ruby.fish'),
+      content  => template('ruby/ruby.fish.erb'),
       priority => 'higher',
     }
     boxen::env_script { 'ruby':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,8 +18,9 @@ class ruby(
 
   if $::osfamily == 'Darwin' {
     boxen::env_script { 'ruby-fish':
-      content  => template('ruby/ruby.fish.erb'),
-      priority => 'higher',
+      content   => template('ruby/ruby.fish.erb'),
+      priority  => 'higher',
+      extension => 'fish',
     }
     boxen::env_script { 'ruby':
       content  => template('ruby/ruby.sh'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,9 +18,10 @@ class ruby(
 
   if $::osfamily == 'Darwin' {
     boxen::env_script { 'ruby-fish':
-      content   => template('ruby/ruby.fish.erb'),
-      priority  => 'higher',
-      extension => 'fish',
+      content    => template('ruby/ruby.fish.erb'),
+      priority   => 'higher',
+      scriptname => 'ruby',
+      extension  => 'fish',
     }
     boxen::env_script { 'ruby':
       content  => template('ruby/ruby.sh'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,10 @@ class ruby(
 
   if $::osfamily == 'Darwin' {
     boxen::env_script { 'ruby':
+      content  => template('ruby/ruby.fish'),
+      priority => 'higher',
+    }
+    boxen::env_script { 'ruby':
       content  => template('ruby/ruby.sh'),
       priority => 'higher',
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class ruby(
   include $provider_class
 
   if $::osfamily == 'Darwin' {
-    boxen::env_script { 'ruby':
+    boxen::env_script { 'ruby-fish':
       content  => template('ruby/ruby.fish'),
       priority => 'higher',
     }

--- a/templates/ruby.fish.erb
+++ b/templates/ruby.fish.erb
@@ -13,9 +13,7 @@ set -gx PATH $RBENV_ROOT/bin $PATH
 eval (rbenv init -)
 
 # Helper for shell prompts and the like
-current_ruby() {
-  echo (rbenv version-name)
-}
+alias current_ruby 'rbenv version-name'
 <%- end -%>
 
 # ruby.sh has chruby here but it's not supported for Fish!

--- a/templates/ruby.fish.erb
+++ b/templates/ruby.fish.erb
@@ -10,7 +10,7 @@ set -gx RBENV_ROOT <%= scope.lookupvar("::ruby::rbenv::prefix") %>
 set -gx PATH $RBENV_ROOT/bin $PATH
 
 # Load rbenv
-eval (rbenv init -)
+source (rbenv init - | psub)
 
 # Helper for shell prompts and the like
 alias current_ruby 'rbenv version-name'

--- a/templates/ruby.fish.erb
+++ b/templates/ruby.fish.erb
@@ -10,11 +10,11 @@ set -gx RBENV_ROOT <%= scope.lookupvar("::ruby::rbenv::prefix") %>
 set -gx PATH $RBENV_ROOT/bin $PATH
 
 # Load rbenv
-eval "$(rbenv init -)"
+eval (rbenv init -)
 
 # Helper for shell prompts and the like
 current_ruby() {
-  echo "$(rbenv version-name)"
+  echo (rbenv version-name)
 }
 <%- end -%>
 

--- a/templates/ruby.fish.erb
+++ b/templates/ruby.fish.erb
@@ -2,7 +2,7 @@
 set -gx PATH <%= scope.lookupvar("::ruby::build::prefix") %>/bin $PATH
 
 # Allow bundler to use all the cores for parallel installation
-set -gx BUNDLE_JOBS=<%= scope.lookupvar("::processorcount") %>
+set -gx BUNDLE_JOBS <%= scope.lookupvar("::processorcount") %>
 
 <%- if scope.lookupvar("::ruby::provider") == "rbenv" -%>
 # Configure RBENV_ROOT and put RBENV_ROOT/bin on PATH


### PR DESCRIPTION
Adds a Fish version of the env script. 

Relies on boxen/puppet-boxen#138 (for the `extension` argument to `env_script`).

Note that `rbenv init -` doesn't work with Fish on 0.4.0 (the latest tagged release). You have to manually pull the latest rbenv: `cd /opt/boxen/rbenv; and git fetch origin; and git reset --hard origin/master`. Sorry, I couldn't see a way to make Puppet get HEAD rather than a tagged version.
