### PR TITLE
Revert "Use --no-document"

### DIFF
--- a/lib/puppet/provider/ruby_gem/rubygems.rb
+++ b/lib/puppet/provider/ruby_gem/rubygems.rb
@@ -92,7 +92,7 @@ Puppet::Type.type(:ruby_gem).provide(:rubygems) do
         target_versions = [@resource[:ruby_version]]
       end
       target_versions.reject { |r| installed_for? r }.each do |ruby|
-        gem "install '#{@resource[:gem]}' --version '#{@resource[:version]}' --source '#{@resource[:source]}' --no-document", ruby
+        gem "install '#{@resource[:gem]}' --version '#{@resource[:version]}' --source '#{@resource[:source]}' --no-rdoc --no-ri", ruby
       end
     end
   rescue => e


### PR DESCRIPTION
Reverts boxen/puppet-ruby#149

As explained in the referenced issue, this restores compatibility with RubyGems 1.8.