### PR TITLE
Add environment variables

### DIFF
--- a/lib/puppet/provider/ruby/rubybuild.rb
+++ b/lib/puppet/provider/ruby/rubybuild.rb
@@ -128,6 +128,8 @@ private
 
     @environment = Hash.new
 
+    @environment["HOME"] = rbenv_root
+    @environment["BUNDLE_BIN_PATH"] = ""
     @environment["RUBY_BUILD_CACHE_PATH"] = cache_path
 
     @environment.merge!(@resource[:environment])

--- a/lib/puppet/provider/ruby/rubybuild.rb
+++ b/lib/puppet/provider/ruby/rubybuild.rb
@@ -128,7 +128,7 @@ private
 
     @environment = Hash.new
 
-    @environment["HOME"] = rbenv_root
+    @environment["HOME"] = prefix
     @environment["BUNDLE_BIN_PATH"] = ""
     @environment["RUBY_BUILD_CACHE_PATH"] = cache_path
 
@@ -148,6 +148,10 @@ private
   end
 
   def prefix
-    "/opt/rubies/#{version}"
+    if Facter.value(:boxen_home)
+      "#{Facter.value(:boxen_home)}/rbenv"
+    else
+      "/opt/rubies"
+    end
   end
 end


### PR DESCRIPTION
`HOME` is required brew command.
`BUNDLE_BIN_PATH` is required for `rbenv install x.y.z` error.
  ```
/Library/Ruby/Gems/2.0.0/gems/bundler-1.12.6/lib/bundler/spec_set.rb:95:in `block in materialize': Could not find rake-10.3.2 in any of the sources (Bundler::GemNotFound)
 ```